### PR TITLE
Allow user to list tracked games

### DIFF
--- a/client.py
+++ b/client.py
@@ -35,7 +35,7 @@ async def on_message(message):
         print('Reading steam list')
         read_games_mapping()
     elif user_input == 'games_m':
-        list_games()
+        log_wishlist_memory()
     elif 'delete_' in user_input:
         game_in_input = re.split('_',user_input)
         game_name = game_in_input[1]
@@ -45,12 +45,14 @@ async def on_message(message):
             delete_game((entry["appid"], entry["name"]))
     elif 'clear' in user_input: 
         clear_wishlist()
+    elif 'games' in user_input: #Allow user to list the games we are tracking
+        await list_games(message)
     else: #If message doesn't match any of the previous checks, add game to list
         await handle_add_game_request(message)
 
-async def handle_add_game_request(user_message):
+async def handle_add_game_request(message):
     #If message doesn't match any of the previous checks, add game to list
-    entry = get_entry(user_message.content.lower())
+    entry = get_entry(message.content.lower())
     print(f'The entry to be added is {entry}.')
     reply = ''
     if entry != None:
@@ -66,6 +68,14 @@ async def handle_add_game_request(user_message):
 
     else:
         reply = 'The game doesn\'t exist on steam, try gamepass'
-    await user_message.reply (reply)
+    await message.reply (reply)
+
+# Get all games we are tracking and reply to the author of the message. 
+async def list_games(message):
+    games = get_game_titles()
+    output = "Games we're tracking:"
+    for count, game in enumerate(games, start=1):
+        output = output + f'\n{count}: {game}'
+    await message.reply(output)
 
 client.run(token)

--- a/steam.py
+++ b/steam.py
@@ -89,14 +89,23 @@ def fetch_game_data(app_id_string) :
         app_data = json.loads(r.text) # JSON - dictionary
         return app_data[app_id_string]['data'] # Internal dictionary of app_id
 
-def list_games():
+# Log the wishlist memory without filtering (used for testing)
+def log_wishlist_memory():
     print(wishlist_json)
 
+# Clear the memory and file wishlist (used mainly for testing)
 def clear_wishlist(): 
     global wishlist_json
     print("Clearing wishlist")
     wishlist_json = {}
     sync_wishlist_file()
+
+# Iterate through all games we track and return a list of game titles
+def get_game_titles(): 
+    games = []
+    for key in wishlist_json:
+        games.append(wishlist_json[key]['name'])
+    return games
 
 # Write the current value stored in games_list_json to the wishlist_file
 # Note: We write to this file for every addition/deletion of games, but only read from it one time: when the bot is ready. 


### PR DESCRIPTION
Would be cool to allow users to query games in the tracker and maybe do something like
![image](https://user-images.githubusercontent.com/27603113/152832517-1255ea0a-169c-4d4b-af38-7f7b949806ce.png)

They could then write 
I play 1

And we could add them as a player to the game, so future queries may allow us to do
Games:
- bot lists games with index

User: 
Who plays 1

Bot outputs status of 1, also on sales we could add who already plays the game. 