### PR TITLE
Sale history and Weekly Friday Check

### DIFF
--- a/client.py
+++ b/client.py
@@ -131,20 +131,43 @@ async def daily_wishlist_check():
 
 @daily_wishlist_check.before_loop
 async def configure_daily_wishlist_check():
-    print('here')
     hour = 10
     minute = 00
     await client.wait_until_ready()
     now = datetime.now()
     future = datetime(now.year, now.month, now.day, hour, minute)
-    print(f'now - hour:{now.hour}, minute:{now.minute}\ntarget - hour:{hour}, minute: {minute}')
     if now.hour > hour or (now.hour == hour and now.minute > minute): 
-        print("Going to next day")
         future += timedelta(days=1)
-    print(future)
-    print(future - now)
+    print(f'delay to start wishlist check loop: {future-now}')
+    await asyncio.sleep((future-now).seconds)
+
+@tasks.loop(hours=168) # 7 day cycle 
+async def friday_reminder():
+    games_on_sale = get_game_sales()
+    channel = client.get_channel(discord_config["channel_id"])
+    message = f"""    
+    Hey buttholes, it\'s friday, checkout these sales before the weekend!
+
+{games_on_sale}
+    """
+    await channel.send(message)
+
+@friday_reminder.before_loop
+async def configure_friday_check():
+    hour = 18
+    minute = 18
+    friday = 5
+    await client.wait_until_ready()
+    now = datetime.now()
+    future = datetime(now.year, now.month, now.day, hour, minute)
+    days = (friday - now.weekday()) % 7
+    if now.hour > hour or (now.hour == hour and now.minute > minute): 
+        days += 7
+    future += timedelta(days=days)
+    print(f'delay to start friday check loop: {future-now}')
     await asyncio.sleep((future-now).seconds)
 
 load_games() 
 daily_wishlist_check.start()
+friday_reminder.start()
 client.run(token)

--- a/client.py
+++ b/client.py
@@ -154,8 +154,8 @@ async def friday_reminder():
 
 @friday_reminder.before_loop
 async def configure_friday_check():
-    hour = 18
-    minute = 18
+    hour = 20
+    minute = 00
     friday = 5
     await client.wait_until_ready()
     now = datetime.now()

--- a/steam.py
+++ b/steam.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import requests
 import json
 from enum import Enum
@@ -72,6 +73,7 @@ def add_game(app_tuple): # app_tuple = (appID, game name)
     
     app_data = {'name' : app_tuple[1]}
     app_data.update(received_app_data)
+    app_data['sale_history'] = build_empty_sale_history()
     print(json.dumps(app_data, indent=4, sort_keys=True))
 
     #  Add if doesn't exist
@@ -146,21 +148,51 @@ def check_game_sales():
     # Fetch all price_overviews
     url = f'https://store.steampowered.com/api/appdetails?filters=price_overview&appids={app_ids_string}'
     result = requests.get(url)
-    games_on_sale = {}
+    sales = {}
+    new_sales = {}
     if result.status_code == 200: 
         sale_data = json.loads(result.text)
         # TODO: clean up loop with map
         #loop through all data and extract price overview
+        
         for app_id in app_ids: 
             price_overview = sale_data[app_id]['data']['price_overview']
-            # If game is on sale, update wishlist and track sale games
-            if price_overview['discount_percent'] > 0:
+            sale_history = wishlist_json[app_id]['sale_history']
+            on_sale_yesterday = sale_history['sale_start'] != None
+            on_sale = price_overview['discount_percent'] > 0
+
+            if on_sale: 
+                if not on_sale_yesterday:
+                    date = datetime.now().date()
+                    print(f"date: {date}")
+                    sale_history['sale_start'] = f'{date}'
+                    wishlist_json[app_id]['price_overview'] = price_overview
+                    new_sales[app_id] = wishlist_json[app_id]
+                else: 
+                    sales[app_id] = wishlist_json[app_id]
+            elif on_sale_yesterday:
+                sale_history['last_sale_start'] = sale_history['sale_start']
+                date = datetime.now().date()
+                sale_history['last_sale_end'] = f'{date}'
+                sale_history['sale_start'] = None
                 wishlist_json[app_id]['price_overview'] = price_overview
-                games_on_sale[app_id] = wishlist_json[app_id]
+
     sync_wishlist_file()
-    print(f'games on sale: {games_on_sale}')
+    print(f'new sales: \n{new_sales}')
+    print(f'still on sale: \n{sales}')
+    return new_sales, sales
+
+def get_game_sales(): 
+    app_ids = wishlist_json.keys()
+    games_on_sale = {}
+    for app_id in app_ids: 
+        if wishlist_json[app_id]['sale_history']['sale_start'] != None:
+            games_on_sale[app_id] = wishlist_json[app_id]
     return games_on_sale
 
+def build_empty_sale_history():
+    sale_history = {'sale_start':None, 'last_sale_start':None, 'last_sale_end':None}
+    return sale_history
 
 class GameAddStatus(Enum):
     EXISTS = 1


### PR DESCRIPTION
This change adds the logic for sale history, this includes: 
1. Each stored game gains a new field, sale_history, which contains:
- sale_start: the start date of the current sale
- last_sale_start: the start date of the last sale
- last_sale_end: the start date of the last sale
2. Sale history is updated in the following cases: 
- Game goes from not on sale to on sale (write current date to sale_start)
- Game goes from on sale to not on sale (write sale_start date to last_sale_start, current date to last_sale_end, nullify sale_start) 
3. Friday push, update all gamers before the weekend of sales (similar logic to the daily check). 