### PR TITLE
Tweak games command reply

### DIFF
--- a/client.py
+++ b/client.py
@@ -76,8 +76,7 @@ async def handle_add_game_request(message, entry):
         elif status ==  GameAddStatus.FREE_GAME:
             reply = 'This game is free'
         else:
-            output = games_were_tracking_string()
-            reply = (f'**{entry["name"].capitalize()}** was successfully added to our tracking list.\nsteam://openurl/https://store.steampowered.com/app/{entry["appid"]}\n {output}')
+            reply = (f'**{entry["name"].capitalize()}** was successfully added to our tracking list.\nsteam://openurl/https://store.steampowered.com/app/{entry["appid"]}\n')
     else:
         reply = 'This game doesn\'t exist on steam, try gamepass.'
     await message.reply (reply)
@@ -96,11 +95,14 @@ async def handle_delete_game_request(message,entry):
 
 # Essentially list_games but without the reply at the bottom, lets us use output to build into other strings
 def list_games_for_reply():
-    games = get_game_titles()
-    output = ""
-    for count, game in enumerate(games, start=1):
-        output = output + f'\n•\t{game.capitalize()}'
-    return output
+    formatted_games = ''
+    games = get_games()
+    print(games)
+    for key in games: 
+        game_title = games[key]['name']
+        game_url = f'steam://openurl/https://store.steampowered.com/app/{key}'
+        formatted_games = formatted_games + f'\n•\t{game_title} - {game_url}'
+    return formatted_games
 
 # Get all games we are tracking and reply to the author of the message. 
 async def handle_list_game_request(message):
@@ -128,7 +130,7 @@ def format_game_for_reply(game, game_id):
     discounted_percent = game['price_overview']["discount_percent"]
     discounted_price = game['price_overview']['final_formatted']
     formatted_discounted_price = discounted_price.replace('CDN$ ','$')
-    formatted_game = f'**{name.capitalize()}** is on sale for {formatted_discounted_price} - {discounted_percent}% off!\n\t  {url}\n'
+    formatted_game = f'**{name}** is on sale for {formatted_discounted_price} - {discounted_percent}% off!\n\t  {url}\n'
     return formatted_game
 
 def format_games_for_reply(games):

--- a/steam.py
+++ b/steam.py
@@ -111,6 +111,9 @@ def get_game_titles():
         games.append(wishlist_json[key]['name'])
     return games
 
+def get_games():
+    return wishlist_json
+
 # Write the current value stored in games_list_json to the wishlist_file
 # Note: We write to this file for every addition/deletion of games, but only read from it one time: when the bot is ready. 
 def sync_wishlist_file():


### PR DESCRIPTION
Add game now only shows the message for adding the game, not the whole list 
Reasoning: someone could just type games to get the list, adding a game should simply confirm it worked. Maybe we can add it back later, but if our list is like 20 games, it'll be a long message. 

When games are printed, it formats 
<game> - <url>